### PR TITLE
fix: Correct prop name in TimelineItem component

### DIFF
--- a/Screens/EditCase/EditCaseScreen.tsx
+++ b/Screens/EditCase/EditCaseScreen.tsx
@@ -733,7 +733,7 @@ const EditCaseScreen: React.FC = () => {
                 .map((event, index, arr) => (
                   <TimelineItem
                     key={event._clientSideId || event.id.toString()}
-                    event={event}
+                    item={event}
                     onEdit={handleEditTimelineEvent}
                     onDelete={handleDeleteTimelineEvent}
                     isLastItem={index === arr.length - 1}


### PR DESCRIPTION
The TimelineItem component was expecting a prop named `item`, but was being passed a prop named `event` from the EditCaseScreen. This caused a `TypeError: Cannot read property 'description' of undefined` because the `item` prop was undefined.

This commit renames the `event` prop to `item` in the EditCaseScreen to match the TimelineItem component's props, which resolves the error.